### PR TITLE
don't let failed parameter decoding throw an uncaught error

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,13 @@ var allowHeader = function(router, resource){
 var dispatch = function(router, req, res, next){
   var route;
 
-  req.route = route = router.getRoute(req.url);
+  try {
+    req.route = route = router.getRoute(req.url);
+  } catch (err) {
+    next(err);
+    return;
+  }
+
   if (!route){
     if (next){
       return next();
@@ -205,4 +211,3 @@ var parentPath = function(path){
   }
   return pieces.join('/');
 };
-

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
   },
   "homepage": "https://github.com/cainus/detour",
   "devDependencies": {
+    "coveralls": "2.6.1",
     "istanbul": "0.2.3",
-    "mocha": "1.16.2",
-    "should": "2.1.1",
     "jshint": "2.4.0",
-    "coveralls": "2.6.1"
+    "mocha": "1.16.2",
+    "request": "^2.79.0",
+    "should": "2.1.1"
   },
   "dependencies": {
     "connect": "3.1.0",


### PR DESCRIPTION
This is similar to how express's router handles this situation. A test case is included.